### PR TITLE
feat(docker): add docker compose file and create container for postgreSQL

### DIFF
--- a/Docker/.env
+++ b/Docker/.env
@@ -1,0 +1,8 @@
+# --- Docker configuration ---
+# Sets the name of the Docker project
+COMPOSE_PROJECT_NAME=cookbook
+
+# --- Docker configuration ---
+#  Sets the user and password for PostgreSQL
+POSTGRES_USER=user
+POSTGRES_PASSWORD=pOLDUProPJ

--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:12
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - cookbook-network
+        
+volumes:
+  postgres_data:
+
+networks:
+  cookbook-network:


### PR DESCRIPTION
## Docker 
Added docker-compose file to project together with the .env file.

---
## PostgreSQL
Container now runs on port 5432 and the login credentials can be found in the .env file. 