### PR TITLE
Fix/interservice communication

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       context: ../cooking-user/
       dockerfile: ../Docker/user.Dockerfile
     ports:
-      - "5000:5000"
+      - "5003:80"
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -31,7 +31,7 @@ services:
       context: ../cooking-user-relations/
       dockerfile: ../Docker/user-relation.Dockerfile
     ports:
-      - "5100:5100"
+      - "5004:80"
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/Controllers/UserController.cs
+++ b/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/Controllers/UserController.cs
@@ -26,7 +26,7 @@ public class UserController : ControllerBase
     }
     [AllowAnonymous]
     [HttpPost]
-    public async Task<IActionResult> AddUser([FromBodx`y] UserDto userDto)
+    public async Task<IActionResult> AddUser([FromBody] UserDto userDto)
     {
         if (!Key.CheckKey(userDto.key))
         {

--- a/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/Controllers/UserController.cs
+++ b/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/Controllers/UserController.cs
@@ -26,7 +26,7 @@ public class UserController : ControllerBase
     }
     [AllowAnonymous]
     [HttpPost]
-    public async Task<IActionResult> AddUser([FromBody] UserDto userDto)
+    public async Task<IActionResult> AddUser([FromBodx`y] UserDto userDto)
     {
         if (!Key.CheckKey(userDto.key))
         {

--- a/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/Startup.cs
+++ b/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/Startup.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using sj2324_5ehif_cooking_user_relations.Application.Infrastructure;
 using sj2324_5ehif_cooking_user_relations.Application.Model;
@@ -26,6 +25,7 @@ public class Startup
 
         services.AddDbContext<UserRelationsContext>(options =>
             options.UseNpgsql(Configuration.GetConnectionString("PostgresConnection")));
+        
         services.AddSwaggerGen(c =>
         {
             c.SwaggerDoc("v1", new OpenApiInfo { Title = "Cooking User-Relations", Version = "v1" });
@@ -39,14 +39,17 @@ public class Startup
         using (var scope = app.Services.CreateScope())
         {
             var services = scope.ServiceProvider;
-            services.GetRequiredService<UserRelationsContext>().Database.EnsureDeleted();
+            if (app.Environment.IsDevelopment())
+            {
+                services.GetRequiredService<UserRelationsContext>().Database.EnsureDeleted();
+            }
             services.GetRequiredService<UserRelationsContext>().Database.EnsureCreated();
         }
 
         if (app.Environment.IsDevelopment())
         {
             app.UseSwagger();
-            app.UseSwaggerUI(c => { c.SwaggerEndpoint("/swagger/v1/swagger.json", "Cooking User V1"); });
+            app.UseSwaggerUI(c => { c.SwaggerEndpoint("/swagger/v1/swagger.json", "Cooking User-Relations V1"); });
         }
 
         app.UseAuthentication();

--- a/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/appsettings.Development.json
+++ b/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/appsettings.Development.json
@@ -1,11 +1,6 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
   "ConnectionStrings": {
     "PostgresConnection": "Server=localhost;Port=5432;Database=db_user_relation;Username=user;Password=pOLDUProPJ"
-  }
+  },
+  "AllowedHosts": "*"
 }

--- a/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/appsettings.Production.json
+++ b/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/appsettings.Production.json
@@ -1,0 +1,6 @@
+{
+  "ConnectionStrings": {
+    "PostgresConnection": "Server=postgres;Port=5432;Database=db_user_relation;Username=user;Password=pOLDUProPJ"
+  },
+  "AllowedHosts": "*"
+}

--- a/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/appsettings.json
+++ b/cooking-user-relations/sj2324-5ehif-cooking-user-relations.Webapi/appsettings.json
@@ -4,9 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "PostgresConnection": "Server=localhost;Port=5432;Database=db_user_relation;Username=user;Password=pOLDUProPJ"
   }
 }

--- a/cooking-user/sj2324-5ehif-cooking-user.Test/UserTests/AuthTest.cs
+++ b/cooking-user/sj2324-5ehif-cooking-user.Test/UserTests/AuthTest.cs
@@ -18,6 +18,7 @@ public class AuthTest
     private readonly UserContext _mockContext;
     private readonly JwtUtils _mockJwtUtils;
     private readonly ILogger<AuthController> _mockLogger;
+    private readonly InterCallService _mockinterCallService;
 
     public AuthTest()
     {
@@ -45,6 +46,7 @@ public class AuthTest
 
         _mockLogger = new Logger<AuthController>(new LoggerFactory());
         _mockJwtUtils = new JwtUtils(_mockConfiguration);
+        _mockinterCallService = new InterCallService(_mockConfiguration);
     }
 
     [Fact]
@@ -97,7 +99,7 @@ public class AuthTest
     private async Task<IActionResult> RegistrationHelper(RegisterModel registerModel)
     {
         var controller = new AuthController(_mockLogger,
-            _mockJwtUtils, new Repository<User>(_mockContext));
+            _mockJwtUtils, new Repository<User>(_mockContext), _mockinterCallService);
 
         return await controller.Register(registerModel);
     }
@@ -105,7 +107,7 @@ public class AuthTest
     private async Task<IActionResult> LoginHelper(LoginModel loginModel)
     {
         var controller = new AuthController(_mockLogger,
-            _mockJwtUtils, new Repository<User>(_mockContext));
+            _mockJwtUtils, new Repository<User>(_mockContext), _mockinterCallService);
 
         return await controller.Login(loginModel);
     }

--- a/cooking-user/sj2324-5ehif-cooking-user.Webapi/Startup.cs
+++ b/cooking-user/sj2324-5ehif-cooking-user.Webapi/Startup.cs
@@ -32,6 +32,29 @@ public class Startup
         services.AddSwaggerGen(c =>
         {
             c.SwaggerDoc("v1", new OpenApiInfo { Title = "Cooking User", Version = "v1" });
+            c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.Http,
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header,
+                Scheme = "bearer",
+                Description = "Please insert JWT token into field"
+            });
+
+            c.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    new string[] { }
+                }
+            });
         });
         services.AddScoped<IJwtUtils, JwtUtils>();
         services.AddScoped<IInterCallService, InterCallService>();
@@ -67,14 +90,12 @@ public class Startup
             if (app.Environment.IsDevelopment())
             {
                 services.GetRequiredService<UserContext>().Database.EnsureDeleted();
-
             }
             services.GetRequiredService<UserContext>().Database.EnsureCreated();
         }
 
         if (app.Environment.IsDevelopment())
         {
-            app.UseSwagger();
             app.UseSwagger();
             app.UseSwaggerUI(c => { c.SwaggerEndpoint("/swagger/v1/swagger.json", "Cooking User V1"); });
         }

--- a/cooking-user/sj2324-5ehif-cooking-user.Webapi/appsettings.Development.json
+++ b/cooking-user/sj2324-5ehif-cooking-user.Webapi/appsettings.Development.json
@@ -1,14 +1,10 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
   "ConnectionStrings": {
+    "_PostgresConnection": "The connection string to the PostgreSQL database.",
     "PostgresConnection": "Server=localhost;Port=5432;Database=db_user;Username=user;Password=pOLDUProPJ"
   },
   "CommunicationServices": {
     "user_endpoints": ["http://localhost:5004/User"]
-  }
+  },
+  "AllowedHosts": "*"
 }

--- a/cooking-user/sj2324-5ehif-cooking-user.Webapi/appsettings.Production.json
+++ b/cooking-user/sj2324-5ehif-cooking-user.Webapi/appsettings.Production.json
@@ -1,14 +1,10 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
   "ConnectionStrings": {
+    "_PostgresConnection": "The connection string to the PostgreSQL database.",
     "PostgresConnection": "Server=postgres;Port=5432;Database=db_user;Username=user;Password=pOLDUProPJ"
   },
   "CommunicationServices": {
-    "user_endpoints": ["http://localhost:5004/User"]
-  }
+    "user_endpoints": ["http://user-relations:80/User"]
+  },
+  "AllowedHosts": "*"
 }

--- a/cooking-user/sj2324-5ehif-cooking-user.Webapi/appsettings.json
+++ b/cooking-user/sj2324-5ehif-cooking-user.Webapi/appsettings.json
@@ -5,17 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ConnectionStrings": {
-    "_PostgresConnection": "The connection string to the PostgreSQL database.",
-    "PostgresConnection": "Server=localhost;Port=5432;Database=db_user;Username=user;Password=pOLDUProPJ"
-  },
   "Jwt": {
     "Key": "ecawiasqrpqrgyhwnolrudpbsrwaynbqdayndnmcehjnwqyouikpodzaqxivwkconwqbhrmxfgccbxbyljguwlxhdlcvxlutbnwjlgpfhjgqbegtbxbvwnacyqnltrby",
     "Issuer": "CookingUser",
     "Audience": "CookingUser"
-  },
-  "CommunicationServices": {
-    "user_endpoints": ["http://localhost:5004/User"]
-  },
-  "AllowedHosts": "*"
+  }
 }


### PR DESCRIPTION
### What was done?
- added authentication to the swagger page so you can use protected endpoints while testing
- fixed AuthTest class to use mocked InterCallService
- fixed docker-compose (appsettings) to enable cross communication in prod and dev
- updated appsettings.json files to only change nescessary settings instead of overwriting
- changed user port to 5003 and user-relations port to 5004 

## How to use JWT-Authentication in Swagger

1. Run Cooking-User project in development (don't forget to set the environment variable!!!) 

you can do it like this:
![image](https://github.com/Die-Spengergasse/sj2324-5ehif-classproject-user-user-relation/assets/77665584/7c026c56-3e45-4d7f-a819-b0f911915821)

```aspnetcore_environment=Development```

2. Since Swagger is only accessible when in development mode access ```http://localhost:5000/swagger/index.html```
3. Then register and/or login to get the token
You will get this:
![image](https://github.com/Die-Spengergasse/sj2324-5ehif-classproject-user-user-relation/assets/77665584/11953f56-634f-450c-98eb-9b46d772b0a4)

Copy the token, in this case:
```eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6IlVTUkFadzBuOEVpZzllUHIwViIsIm5iZiI6MTcwNTQwNTg5MywiZXhwIjoxNzA1NDQ5MDkzLCJpYXQiOjE3MDU0MDU4OTMsImlzcyI6IkNvb2tpbmdVc2VyIiwiYXVkIjoiQ29va2luZ1VzZXIifQ.BQ8U6k8OxzehM0eVOrp-KU3AxUhIEQbjxqBOWhMh7PI```

4. Scroll all the way to the top and locate this:
![image](https://github.com/Die-Spengergasse/sj2324-5ehif-classproject-user-user-relation/assets/77665584/c16fbc3a-ea6c-4795-a3d6-a114b99d003d)
Click on it and copy in the token, then Authorize.
![image](https://github.com/Die-Spengergasse/sj2324-5ehif-classproject-user-user-relation/assets/77665584/9162f163-fb04-4890-9420-8b88961a6ffa)

5. Thats it! Now you can access protected endpoints!


P.S.: Lmk if I should add any additional tests or something else
